### PR TITLE
A little improvement of text data acquisition

### DIFF
--- a/browser/all_files_new/file_types/texts.js
+++ b/browser/all_files_new/file_types/texts.js
@@ -14,17 +14,16 @@ export async function parse(chunk) {
     const textDecoder = new TextDecoder("utf-8", {fatal: true, ignoreBOM: false})
 
     const dataView = new DataView(chunk.data)
+    const offsetLength = dataView.getUint16(0)
     let ptr = 0
 
     /** @type {string[]} */
     const texts = []
-    while (ptr < dataView.byteLength) {
+    while (ptr < offsetLength) {
         const textAddress = dataView.getUint16(ptr)
         ptr += 2
 
         const textLength = dataView.getUint16(textAddress)
-        if (textLength === 1 && dataView.getUint8(textAddress + 2) === 0x30)
-            break // The last text is "0"
         const text = textDecoder.decode(dataView.buffer.slice(textAddress + 2, textAddress + 2 + textLength))
         texts.push(text)
     }


### PR DESCRIPTION
language file structure is like that
```
(the number of texts) * 2 bytes -> tot = text_offset_table (uint16, bigendian)

for (i = 0; i < tot.byteLength / 2; i++)
{
	seek to tot[i]
	2 bytes -> text_length
	text_length bytes -> text
}
```

We can get the number of texts by first element in offset table
```
var not // number of texts
not = tot[0] / 2 // we can get the number of texts like that
```

Another point to note is that the last "0" in the Diamond Rush language file is used to set the alignment of the title. The value of 0 is left-aligned, and the value of 1 is right-aligned (probably used to adapt to some special languages)
![IMG_20250506_203028](https://github.com/user-attachments/assets/2958a5fc-e650-42c8-bd5d-dda134ad6bf6)
